### PR TITLE
Revert "Use ansible-network/ansible-zuul-job"

### DIFF
--- a/zuul.d/jobs.yaml
+++ b/zuul.d/jobs.yaml
@@ -7,7 +7,7 @@
     post-run:
       - playbooks/base/post.yaml
     roles:
-      - zuul: ansible-network/ansible-zuul-jobs
+      - zuul: sf-jobs
       - zuul: openstack-infra/zuul-jobs
     timeout: 1800
     attempts: 3


### PR DESCRIPTION
Revert back to working sf-jobs, to make zuul happy again.

This reverts commit 753473c5f6800bb538e88aebc93350d6e92620d9.

Revert "Use gundalow-org/ansible-zuul-jobs"

This reverts commit 67a61c900a80d968f615b81ae134df4baaa8ef02.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>