### PR TITLE
Roles from ansible-network/ansible-zuul-jobs

### DIFF
--- a/zuul.d/jobs.yaml
+++ b/zuul.d/jobs.yaml
@@ -7,7 +7,7 @@
     post-run:
       - playbooks/base/post.yaml
     roles:
-      - zuul: sf-jobs
+      - zuul: ansible-network/ansible-zuul-jobs
       - zuul: openstack-infra/zuul-jobs
     timeout: 1800
     attempts: 3


### PR DESCRIPTION
Use the Ansible version of roles, rather than sf-jobs.

This allows the Ansible Network team to create tests for their specific needs.