### PR TITLE
Create base-test jobs for staging changes

### DIFF
--- a/zuul.d/jobs.yaml
+++ b/zuul.d/jobs.yaml
@@ -1,4 +1,24 @@
 ---
+# Changes to this job require a special procedure, because they can
+# not be tested before landing, and if they are faulty, they will
+# break all jobs, meaning subsequent corrections will not be able to
+# land.  To make a change:
+#
+# 1) Ensure that base-test and its playbooks are identical to base.
+# 2) Make the change to base-test and/or its playbooks.
+# 3) Merge the change from step 2.  No jobs normally use base-test, so
+#    this is safe.
+# 4) Propose a change to a job to reparent it to base-test.  Choose a
+#    job which will exercise whatever you are changing.  The
+#    "unittests" job in zuul-jobs is a good choice.  Use [DNM] in the
+#    commit subject so that people know not to merge the change.  Set
+#    it to "Work in progress" so people don't review it.
+# 5) Once test results arrive for the change in step 2, make a change
+#    which copies the job and/or playbooks of base-test to base.  In
+#    the commit message, link to (without using Depends-On:) the
+#    change from step 4 so reviewers can see the test results.
+# 6) Once the change in step 5 merges, abandon the change from step 4.
+
 - job:
     name: base
     parent: null
@@ -8,6 +28,27 @@
       - playbooks/base/post.yaml
     roles:
       - zuul: ansible-network/ansible-zuul-jobs
+      - zuul: openstack-infra/zuul-jobs
+    timeout: 1800
+    attempts: 3
+    secrets:
+      - site_ansiblelogs
+    nodeset:
+      nodes:
+        - name: container
+          label: centos-oci
+
+- job:
+    name: base-test
+    parent: null
+    description: |
+      A job to test changes to the base job without disturbing the
+      main job in production.  Not for general use.
+    pre-run: playbooks/base-test/pre.yaml
+    post-run:
+      - playbooks/base-test/post.yaml
+    roles:
+      - zuul: sf-jobs
       - zuul: openstack-infra/zuul-jobs
     timeout: 1800
     attempts: 3

--- a/zuul.d/projects.yaml
+++ b/zuul.d/projects.yaml
@@ -4,3 +4,6 @@
     check:
       jobs:
         - noop
+    gate:
+      jobs:
+        - noop


### PR DESCRIPTION
Because it is possible to break zuul with changes to base, we really
need a way to properly stage these jobs without breaking running jobs.

This is a process we currently use in openstack-infra and has been
very helpful to catching issues.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>