### PR TITLE
Still use sf-jobs in base

### DIFF
--- a/zuul.d/jobs.yaml
+++ b/zuul.d/jobs.yaml
@@ -8,6 +8,7 @@
       - playbooks/base/post.yaml
     roles:
       - zuul: ansible-network/ansible-zuul-jobs
+      - zuul: sf-jobs
       - zuul: openstack-infra/zuul-jobs
     timeout: 1800
     attempts: 3


### PR DESCRIPTION
We still need sf-jobs in base, as it contains roles needed for upload
logs to log servers.  There is an option in zuul which does allow us
to overload jobs in sf-jobs, called shadowing. We'll want to do this
in zuuls configuration, to replace sf-jobs ansible-lint with
ansible-zuul-jobs ansible-lint.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>