### PR TITLE
Fix typo in gate status-url

### DIFF
--- a/zuul.d/pipelines.yaml
+++ b/zuul.d/pipelines.yaml
@@ -59,7 +59,7 @@
     start:
       github.com:
         status: 'pending'
-        status-url: "https://softwarefactory-project.io/zuul/status.html"
+        status-url: 'https://ansible.softwarefactory-project.io/zuul/status.html'
         comment: false
     success:
       github.com:


### PR DESCRIPTION
Use the proper status.html page for gate jobs.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>