### PR TITLE
Disable Zuul merge (no gate)

### DIFF
--- a/zuul.d/projects.yaml
+++ b/zuul.d/projects.yaml
@@ -4,6 +4,3 @@
     check:
       jobs:
         - noop
-    gate:
-      jobs:
-        - noop


### PR DESCRIPTION
We don't currently want Zuul to merge any PR as
* We haven't defined who can give +1
* We haven't defined who/how many approvals are needed before merging