### PR TITLE
Disable gate-pipeline till we've got enough tests in place

### DIFF
--- a/zuul.d/pipelines.yaml
+++ b/zuul.d/pipelines.yaml
@@ -64,7 +64,7 @@
     success:
       github.com:
         status: 'success'
-        merge: true
+        merge: false
       sqlreporter:
     failure:
       github.com:


### PR DESCRIPTION
We don't want Zuul to merge PRs at the moment as:
* We don't have a full set of Zuul test in place yet
* We haven't defined how many shipit's should be needed before PRs can be auto merged