### PR TITLE
Add base-test playbooks and test-prepare-workspace role

### DIFF
--- a/playbooks/base-test/post.yaml
+++ b/playbooks/base-test/post.yaml
@@ -1,0 +1,22 @@
+---
+- hosts: localhost
+  roles:
+    - role: add-fileserver
+      fileserver: "{{ site_ansiblelogs }}"
+    - emit-ara-html
+
+- hosts: "{{ site_ansiblelogs.fqdn }}"
+  tasks:
+    # Use a block because play vars doesn't take precedence on roles vars
+    - block:
+        - import_role: name=upload-logs
+      vars:
+        zuul_log_url: "{{ site_ansiblelogs.url }}"
+        zuul_logserver_root: "{{ site_ansiblelogs.path }}"
+
+- hosts: localhost
+  ignore_errors: yes
+  roles:
+    - role: submit-logstash-jobs
+      logstash_gearman_server: "ansible.softwarefactory-project.io"
+      logstash_gearman_server_port: 4731

--- a/playbooks/base-test/pre.yaml
+++ b/playbooks/base-test/pre.yaml
@@ -1,0 +1,5 @@
+---
+- hosts: all
+  roles:
+    - test-prepare-workspace
+    - role: validate-host

--- a/roles/test-prepare-workspace/README.rst
+++ b/roles/test-prepare-workspace/README.rst
@@ -1,0 +1,7 @@
+Prepare remote workspaces
+
+This role is intended to run before any other role in a Zuul job.
+
+It starts the Zuul console streamer on every host in the inventory,
+and then copies the prepared source repos to the working directory on
+every host.

--- a/roles/test-prepare-workspace/defaults/main.yaml
+++ b/roles/test-prepare-workspace/defaults/main.yaml
@@ -1,0 +1,1 @@
+zuul_workspace_root: .

--- a/roles/test-prepare-workspace/tasks/main.yaml
+++ b/roles/test-prepare-workspace/tasks/main.yaml
@@ -1,0 +1,11 @@
+# TODO(pabelanger): Handle cleanup on static nodes
+- name: Start zuul_console daemon.
+  zuul_console:
+  tags:
+    # Avoid "no action detected in task" linter error
+    - skip_ansible_lint
+
+- name: Synchronize src repos to workspace directory.
+  synchronize:
+    dest: "{{ zuul_workspace_root }}"
+    src: "{{ zuul.executor.src_root }}"

--- a/zuul.d/jobs.yaml
+++ b/zuul.d/jobs.yaml
@@ -49,6 +49,7 @@
     post-run:
       - playbooks/base-test/post.yaml
     roles:
+      - zuul: ansible-network/ansible-zuul-jobs
       - zuul: sf-jobs
       - zuul: openstack-infra/zuul-jobs
     timeout: 1800


### PR DESCRIPTION
We're trying to debug a problem with prepare-workspace, so we need
a version which omits no_log.