### PR TITLE
Add cloud-vpn semaphores

### DIFF
--- a/zuul.d/semaphores.yaml
+++ b/zuul.d/semaphores.yaml
@@ -1,0 +1,6 @@
+- semaphore:
+    name: clous-vpn-aws-to-aws-us-east-1
+    max: 2
+- semaphore:
+    name: clous-vpn-aws-to-aws-us-east-2
+    max: 2

--- a/zuul.d/semaphores.yaml
+++ b/zuul.d/semaphores.yaml
@@ -1,6 +1,6 @@
 - semaphore:
-    name: clous-vpn-aws-to-aws-us-east-1
+    name: cloud-vpn-aws-to-aws-us-east-1
     max: 2
 - semaphore:
-    name: clous-vpn-aws-to-aws-us-east-2
+    name: cloud-vpn-aws-to-aws-us-east-2
     max: 2


### PR DESCRIPTION
There is a limit of 5 VPCs per region.
Creating a semaphore for each region that allows creating a max
of 4 VPCs.
Each aws to aws test creates 2 VPCs, so that allows us to run 2 jobs
per region by acquiring the semaphore.