### PR TITLE
Switch to gate label to approve PRs to be added to gate pipeline

### DIFF
--- a/zuul.d/pipelines.yaml
+++ b/zuul.d/pipelines.yaml
@@ -47,7 +47,7 @@
           - permission: write
             type: approved
         label:
-          - mergeit
+          - gate
         status: "softwarefactory-project-zuul\\[bot\\]:ansible-network/check:success"
         open: True
         current-patchset: True
@@ -62,7 +62,7 @@
         - event: pull_request
           action: labeled
           label:
-            - mergeit
+            - gate
     start:
       github.com:
         status: 'pending'


### PR DESCRIPTION
This changes the usage of mergeit label to gate, which is more zuuly and
provided a better discription of what is happing in the workflow.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>