### PR TITLE
Remove base job from zuul-config

### DIFF
--- a/zuul.d/jobs.yaml
+++ b/zuul.d/jobs.yaml
@@ -9,19 +9,21 @@
 # break all jobs, meaning subsequent corrections will not be able to
 # land.  To make a change:
 #
-# 1) Ensure that base-test and its playbooks are identical to base.
-# 2) Make the change to base-test and/or its playbooks.
-# 3) Merge the change from step 2.  No jobs normally use base-test, so
-#    this is safe.
-# 4) Propose a change to a job to reparent it to base-test.  Choose a
-#    job which will exercise whatever you are changing.  The
+# 1) Ensure that base-minimal-test and its playbooks are identical to
+#    base-minimal.
+# 2) Make the change to base-minimal-test and/or its playbooks.
+# 3) Merge the change from step 2.  No jobs normally use
+#    base-minimal-test, so this is safe.
+# 4) Propose a change to a job to reparent it to base-minimal-test.
+#    Choose a job which will exercise whatever you are changing.  The
 #    "unittests" job in zuul-jobs is a good choice.  Use [DNM] in the
 #    commit subject so that people know not to merge the change.  Set
 #    it to "Work in progress" so people don't review it.
 # 5) Once test results arrive for the change in step 2, make a change
-#    which copies the job and/or playbooks of base-test to base.  In
-#    the commit message, link to (without using Depends-On:) the
-#    change from step 4 so reviewers can see the test results.
+#    which copies the job and/or playbooks of base-minimal-test to
+#    base-minimal. In the commit message, link to (without using
+#    Depends-On:) the change from step 4 so reviewers can see the
+#    test results.
 # 6) Once the change in step 5 merges, abandon the change from step 4.
 
 - job:
@@ -87,12 +89,6 @@
           label: dib-fedora-27
         - name: appliance
           label: ansible-network-vqfx
-
-# TODO(pabelanger): Move to ansible-network/ansible-zuul-jobs once we are able to shadow jobs in zuul.
-- job:
-    name: base
-    parent: base-minimal
-
 
 - job:
     name: cloud-vpn-aws-csr-to-aws-vpn


### PR DESCRIPTION
This job now lives in ansible-zuul-jobs, as an untrusted job.  We can
also update our documentation around base-minimal / base-minimal-test.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>