### PR TITLE
Update base-minimal-test with ansible-centos-7 nodeset

### DIFF
--- a/zuul.d/jobs.yaml
+++ b/zuul.d/jobs.yaml
@@ -62,8 +62,8 @@
       - site_ansiblelogs
     nodeset:
       nodes:
-        - name: container
-          label: runc-fedora
+        - name: centos-7
+          label: ansible-centos-7
 
 - job:
     name: base-controller-appliance-minimal-test


### PR DESCRIPTION
We want to start running jobs in vexxhost by default. This means
updating our base nodeset for all jobs to ansible-centos-7.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>