### PR TITLE
Remove sf-jobs from base-minimal-test

### DIFF
--- a/zuul.d/jobs.yaml
+++ b/zuul.d/jobs.yaml
@@ -56,7 +56,6 @@
     post-run:
       - playbooks/base-minimal-test/post.yaml
     roles:
-      - zuul: sf-jobs
       - zuul: openstack-infra/zuul-jobs
     timeout: 1800
     attempts: 3


### PR DESCRIPTION
We want to break our dependency on rdocloud, this means for now dropping
support of sf-jobs on our base-minimal-test job.  We should ask SF to
mirror this repo to github.com, to avoid outages with rdo-cloud.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>