### PR TITLE
base-test: Remove logstash for the moment

### DIFF
--- a/playbooks/base-minimal-test/post.yaml
+++ b/playbooks/base-minimal-test/post.yaml
@@ -13,10 +13,3 @@
       vars:
         zuul_log_url: "{{ site_ansiblelogs.url }}"
         zuul_logserver_root: "{{ site_ansiblelogs.path }}"
-
-- hosts: localhost
-  ignore_errors: yes
-  roles:
-    - role: submit-logstash-jobs
-      logstash_gearman_server: "ansible-network.softwarefactory-project.io"
-      logstash_gearman_server_port: 4731


### PR DESCRIPTION
Because we dropped the dependency on sf-jobs, we no longer have access
to submit-logstash-jobs. Moving forward, we can either in-tree this role
or request it moves to zuul-jobs.  But given we are no using logstash
right now, we can opt to remove it for now.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>