### PR TITLE
Promote base-minimal-test pre-run changes

### DIFF
--- a/playbooks/base-minimal/pre.yaml
+++ b/playbooks/base-minimal/pre.yaml
@@ -1,5 +1,21 @@
----
+- hosts: localhost
+  tasks:
+    - name: Run emit-job-header role
+      include_role:
+        name: emit-job-header
+      vars:
+        zuul_log_url: http://ansible-network.softwarefactory-project.io/logs/an
+
+    - name: Run log-inventory role
+      include_role:
+        name: log-inventory
+
 - hosts: all
-  roles:
-    - prepare-workspace
-    - role: validate-host
+  tasks:
+    - name: Run prepare-workspace role
+      include_role:
+        name: prepare-workspace
+
+    - name: Run validate-host role
+      include_role:
+        name: validate-host


### PR DESCRIPTION
This promotes the changes needed for emit-job-header and log-inventory
roles. Which as been tested at:

  https://ansible-network.softwarefactory-project.io/logs/an/38/38/59c92af521135c6459718b1dcbd178826759c706/check/tox-docs/50fcb9a/

This also switches to using include_roles to allow for more complex
playbooks.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>