### PR TITLE
Promote base-minimal-test changes

### DIFF
--- a/playbooks/base-minimal/post.yaml
+++ b/playbooks/base-minimal/post.yaml
@@ -13,10 +13,3 @@
       vars:
         zuul_log_url: "{{ site_ansiblelogs.url }}"
         zuul_logserver_root: "{{ site_ansiblelogs.path }}"
-
-- hosts: localhost
-  ignore_errors: yes
-  roles:
-    - role: submit-logstash-jobs
-      logstash_gearman_server: "ansible-network.softwarefactory-project.io"
-      logstash_gearman_server_port: 4731


### PR DESCRIPTION
Remove logstash integration for now, we are planning on moving to swift
for logs in vexxhost, which means we won't have logs indexes any more.

Also, we'd like to remove the dependency on sf-jobs, since they are
currently hosted in rdocloud, which results is job failures when the
cloud is having networking issues.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>