### PR TITLE
Promote base-minimal-test changes

### DIFF
--- a/zuul.d/jobs.yaml
+++ b/zuul.d/jobs.yaml
@@ -35,7 +35,6 @@
     post-run:
       - playbooks/base-minimal/post.yaml
     roles:
-      - zuul: sf-jobs
       - zuul: openstack-infra/zuul-jobs
     timeout: 1800
     attempts: 3


### PR DESCRIPTION
Remove sf-jobs role from base-minimal. This will break the dependency on
rdocloud for SF roles. Long term, if we want to use these roles, we
should ask for them to be mirrored to github.com.  Given have poor the
network is for rdocloud.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>