### PR TITLE
Switch cloud_vpn role to tox-linters

### DIFF
--- a/zuul.d/projects.yaml
+++ b/zuul.d/projects.yaml
@@ -17,7 +17,7 @@
     name: ansible-network/cloud_vpn
     check:
       jobs:
-        - linters
+        - tox-linters
         - cloud-vpn-aws-csr-to-aws-vpn
         - cloud-vpn-aws-csr-to-aws-vpn-bgp
         - cloud-vpn-aws-csr-to-aws-vyos
@@ -26,7 +26,7 @@
         - cloud-vpn-aws-vyos-to-aws-vyos-bgp
     gate:
       jobs:
-        - linters
+        - tox-linters
         - cloud-vpn-aws-csr-to-aws-vpn
         - cloud-vpn-aws-csr-to-aws-vpn-bgp
         - cloud-vpn-aws-csr-to-aws-vyos


### PR DESCRIPTION
As we remove the dependency on sf-jobs, we need to update projects to
use jobs from zuul-jobs. This switches to tox-linters.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>