### PR TITLE
Promote centos-7 nodeset to base-minimal

### DIFF
--- a/zuul.d/jobs.yaml
+++ b/zuul.d/jobs.yaml
@@ -41,10 +41,7 @@
     attempts: 3
     secrets:
       - site_ansiblelogs
-    nodeset:
-      nodes:
-        - name: container
-          label: runc-fedora
+    nodeset: centos-7
 
 - job:
     name: base-minimal-test
@@ -61,10 +58,7 @@
     attempts: 3
     secrets:
       - site_ansiblelogs
-    nodeset:
-      nodes:
-        - name: centos-7
-          label: ansible-centos-7
+    nodeset: centos-7
 
 - job:
     name: base-controller-appliance-minimal-test


### PR DESCRIPTION
Now that we have confirmed centos-7 works as expected in vexxhost, we
can move this to our default nodeset in base-minimal. This is another
step to remove the dependency on rdo-cloud.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>