### PR TITLE
Remove attempts value from jobs

### DIFF
--- a/zuul.d/jobs.yaml
+++ b/zuul.d/jobs.yaml
@@ -37,7 +37,6 @@
     roles:
       - zuul: openstack-infra/zuul-jobs
     timeout: 1800
-    attempts: 3
     secrets:
       - site_ansiblelogs
     nodeset: centos-7
@@ -54,7 +53,6 @@
     roles:
       - zuul: openstack-infra/zuul-jobs
     timeout: 1800
-    attempts: 3
     secrets:
       - site_ansiblelogs
     nodeset: centos-7
@@ -72,7 +70,6 @@
       - zuul: sf-jobs
       - zuul: openstack-infra/zuul-jobs
     timeout: 1800
-    attempts: 3
     secrets:
       - site_ansiblelogs
     nodeset:


### PR DESCRIPTION
The default is 3, so no need to set this value.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>