### PR TITLE
Replace prepare-workspace with start-zuul-console

### DIFF
--- a/playbooks/base-minimal-test/pre.yaml
+++ b/playbooks/base-minimal-test/pre.yaml
@@ -12,9 +12,9 @@
 
 - hosts: all
   tasks:
-    - name: Run prepare-workspace role
+    - name: Run start-zuul-console role
       include_role:
-        name: prepare-workspace
+        name: start-zuul-console
 
     - name: Run validate-host role
       include_role:


### PR DESCRIPTION
We've moved prepare-workspace into our base playbook, but doing that
means we first should use start-zuul-console. This allows us to view
ansible output in realtime.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>