### PR TITLE
Remove validate-host from base-minimal-test

### DIFF
--- a/playbooks/base-minimal-test/pre.yaml
+++ b/playbooks/base-minimal-test/pre.yaml
@@ -15,7 +15,3 @@
     - name: Run start-zuul-console role
       include_role:
         name: start-zuul-console
-
-    - name: Run validate-host role
-      include_role:
-        name: validate-host


### PR DESCRIPTION
We actually want to move this role into our base job. This allows us to
first test it before promoting the change to base-minimal.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>