### PR TITLE
Upload logs to vexxhost swift for base-minimal-test

### DIFF
--- a/playbooks/base-minimal-test/post-logs.yaml
+++ b/playbooks/base-minimal-test/post-logs.yaml
@@ -1,0 +1,17 @@
+---
+- hosts: localhost
+  tasks:
+    - name: Run ara-report role
+      include_role:
+        name: ara-report
+
+    - name: Run htmlify-logs role
+      include_role:
+        name: htmlify-logs
+
+    - name: Run upload-logs-swift role
+      include_role:
+        name: upload-logs-swift
+      vars:
+        zuul_log_cloud_config: "{{ vexxhost_clouds_yaml }}"
+        zuul_log_partition: True

--- a/zuul.d/jobs.yaml
+++ b/zuul.d/jobs.yaml
@@ -49,12 +49,12 @@
       main job in production.  Not for general use.
     pre-run: playbooks/base-minimal-test/pre.yaml
     post-run:
-      - playbooks/base-minimal-test/post.yaml
+      - playbooks/base-minimal-test/post-swift.yaml
     roles:
       - zuul: openstack-infra/zuul-jobs
     timeout: 1800
     secrets:
-      - site_ansiblelogs
+      - vexxhost_clouds_yaml
     nodeset: centos-7
 
 - job:


### PR DESCRIPTION
This allows us to start using swift from vexxhost for all logs. This
means one less things we need to manage and depend on in RDOcloud.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>