### PR TITLE
Set the default-branch to devel for cloud_vpn

### DIFF
--- a/zuul.d/projects.yaml
+++ b/zuul.d/projects.yaml
@@ -15,6 +15,7 @@
 
 - project:
     name: ansible-network/cloud_vpn
+    default-branch: devel
     check:
       jobs:
         - tox-linters


### PR DESCRIPTION
This is so we can use depends-on header properly. Also, we should
discuss about switching all projects back to master. But that is a
larger discussion.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>