### PR TITLE
base-minimal-test: Restore post.yaml playbook

### DIFF
--- a/playbooks/base-minimal-test/post-logs.yaml
+++ b/playbooks/base-minimal-test/post-logs.yaml
@@ -9,9 +9,11 @@
       include_role:
         name: htmlify-logs
 
-    - name: Run upload-logs-swift role
-      include_role:
-        name: upload-logs-swift
-      vars:
-        zuul_log_cloud_config: "{{ vexxhost_clouds_yaml }}"
-        zuul_log_partition: True
+    - block:
+      - name: Run upload-logs-swift role
+        include_role:
+          name: upload-logs-swift
+        vars:
+          zuul_log_cloud_config: "{{ vexxhost_clouds_yaml }}"
+          zuul_log_partition: True
+      ignore_errors: True

--- a/playbooks/base-minimal-test/post.yaml
+++ b/playbooks/base-minimal-test/post.yaml
@@ -3,7 +3,6 @@
   roles:
     - role: add-fileserver
       fileserver: "{{ site_ansiblelogs }}"
-    - emit-ara-html
 
 - hosts: "{{ site_ansiblelogs.fqdn }}"
   tasks:

--- a/zuul.d/jobs.yaml
+++ b/zuul.d/jobs.yaml
@@ -50,6 +50,7 @@
     pre-run: playbooks/base-minimal-test/pre.yaml
     post-run:
       - playbooks/base-minimal-test/post-logs.yaml
+      - playbooks/base-minimal-test/post.yaml
     roles:
       - zuul: openstack-infra/zuul-jobs
     timeout: 1800


### PR DESCRIPTION
While we are debugging upload-logs-swift, add back legacy upload method,
until working.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>