### PR TITLE
Remove extra auth fields in vexxhost_clouds_yaml secret

### DIFF
--- a/zuul.d/secrets.yaml
+++ b/zuul.d/secrets.yaml
@@ -4,11 +4,8 @@
 - secret:
     name: vexxhost_clouds_yaml
     data:
-      auth_type: password
       profile: vexxhost
       auth:
-        # TODO(pabelanger): remove after https://review.openstack.org/585780
-        auth_url: "https://auth.vexxhost.net"
         password: !encrypted/pkcs1-oaep
           - iqsf7Mzbh3eklmdLGioghFC14K14DDAKNxTNwGE91ME7zafYRYYrb+D5OgGHxveWsgVrX
             2CiK1dRVAUCifyYPhx9ymvaQmtxvqtOCmZrGKzuBrGrd1JmQfOXag487y57hG47QKrQWU


### PR DESCRIPTION
Now that zuul-executors have the latest version openstacksdk, we can
remove these settings.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>