### PR TITLE
base-test-minimal: Update auth settings for vexxhost secret

### DIFF
--- a/zuul.d/secrets.yaml
+++ b/zuul.d/secrets.yaml
@@ -4,8 +4,11 @@
 - secret:
     name: vexxhost_clouds_yaml
     data:
+      auth_type: password
       profile: vexxhost
       auth:
+        # TODO(pabelanger): remove after https://review.openstack.org/585780
+        auth_url: "https://auth.vexxhost.net/v3"
         password: !encrypted/pkcs1-oaep
           - iqsf7Mzbh3eklmdLGioghFC14K14DDAKNxTNwGE91ME7zafYRYYrb+D5OgGHxveWsgVrX
             2CiK1dRVAUCifyYPhx9ymvaQmtxvqtOCmZrGKzuBrGrd1JmQfOXag487y57hG47QKrQWU


### PR DESCRIPTION
Actually, it seems we do still need these settings, that would seem to
imply we are not running the latest openstacksdk.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>