### PR TITLE
Update vexxhost_clouds_yaml secret info

### DIFF
--- a/zuul.d/secrets.yaml
+++ b/zuul.d/secrets.yaml
@@ -22,8 +22,8 @@
             Jd3hI0BllF3j93wbg2EISj8j6jtJwTSYW9IdKraLLWNEdxllanuQfEG/BsfFxQ=
         username: '5e001497-1943-49f4-b39a-0585cf0cd624'
         project_name: 'e2ec7f23-4152-44c8-9c90-309191f8f3fd'
-        project_domain_name: default
-        user_domain_name: default
+        project_domain_id: default
+        user_domain_id: default
       region_name: ca-ymq-1
 
 - secret:


### PR DESCRIPTION
Switch to using the same syntax openstack-infra is using for swift. For
some reason we are getting auth failures with openstacksdk.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>