### PR TITLE
Move prepare-workspace back to trusted context

### DIFF
--- a/playbooks/base-minimal-test/pre.yaml
+++ b/playbooks/base-minimal-test/pre.yaml
@@ -15,3 +15,7 @@
     - name: Run start-zuul-console role
       include_role:
         name: start-zuul-console
+
+    - name: Run prepare-workspace role
+      include_role:
+        name: prepare-workspace

--- a/playbooks/base-minimal/pre.yaml
+++ b/playbooks/base-minimal/pre.yaml
@@ -15,3 +15,7 @@
     - name: Run start-zuul-console role
       include_role:
         name: start-zuul-console
+
+    - name: Run prepare-workspace role
+      include_role:
+        name: prepare-workspace


### PR DESCRIPTION
Until we debug why cloning ansible/ansible fails as untrusted job,
revert this change so yang jobs work.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>