### PR TITLE
Remove approved status from gate pipeline

### DIFF
--- a/zuul.d/pipelines.yaml
+++ b/zuul.d/pipelines.yaml
@@ -43,9 +43,6 @@
     precedence: high
     require:
       github.com:
-        review:
-          - permission: write
-            type: approved
         label:
           - mergeit
         status: "softwarefactory-project-zuul\\[bot\\]:ansible-network/check:success"
@@ -53,9 +50,6 @@
         current-patchset: True
     trigger:
       github.com:
-        - event: pull_request_review
-          action: submitted
-          state: approved
         - event: pull_request
           action: status
           status: "softwarefactory-project-zuul\\[bot\\]:ansible-network/check:success"


### PR DESCRIPTION
Until we discuss a better way to deal with single user repos, it is
almost impossible to gate a repo.  Github doesn't allow a user to code
review their own patches.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>