### PR TITLE
Add per node SSH keys for jobs

### DIFF
--- a/playbooks/base-minimal-test/post-ssh.yaml
+++ b/playbooks/base-minimal-test/post-ssh.yaml
@@ -1,0 +1,8 @@
+- hosts: all
+  # NOTE(pabelanger): We ignore_errors for the following tasks as not to fail
+  # successful jobs.
+  ignore_errors: yes
+  tasks:
+    - name: Run remove-build-sshkey role
+      include_role:
+        name: remove-build-sshkey

--- a/playbooks/base-minimal-test/pre.yaml
+++ b/playbooks/base-minimal-test/pre.yaml
@@ -12,6 +12,10 @@
 
 - hosts: all
   tasks:
+    - name: Run add-build-sshkey role
+      include_role:
+        name: add-build-sshkey
+
     - name: Run start-zuul-console role
       include_role:
         name: start-zuul-console

--- a/zuul.d/jobs.yaml
+++ b/zuul.d/jobs.yaml
@@ -50,6 +50,7 @@
     pre-run: playbooks/base-minimal-test/pre.yaml
     post-run:
       - playbooks/base-minimal-test/post-logs.yaml
+      - playbooks/base-minimal-test/post-ssh.yaml
     roles:
       - zuul: openstack-infra/zuul-jobs
     timeout: 1800


### PR DESCRIPTION
This creates per job run SSH public / private keys for nodes, in an
effort to help reduce the attack vector if we some how leak an SSH key.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>