### PR TITLE
Promote fedora-latest nodeset for base-minimal

### DIFF
--- a/zuul.d/jobs.yaml
+++ b/zuul.d/jobs.yaml
@@ -40,7 +40,7 @@
     timeout: 1800
     secrets:
       - site_ansiblelogs
-    nodeset: centos-7
+    nodeset: fedora-latest
 
 - job:
     name: base-minimal-test


### PR DESCRIPTION
All jobs will now default to fedora-latest (fedora-28) so we can also
have python3 support.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>