### PR TITLE
Remove hardcoded home directory for zuul user

### DIFF
--- a/roles/run-ansible-role-tests/tasks/main.yaml
+++ b/roles/run-ansible-role-tests/tasks/main.yaml
@@ -1,4 +1,4 @@
 ---
-- command: "/home/zuul-worker/.local/bin/ansible-playbook -i {{ test_inventory }} {{ test_entrypoint }} {{ test_options }}"
+- command: "{{ ansible_user_dir }}/.local/bin/ansible-playbook -i {{ test_inventory }} {{ test_entrypoint }} {{ test_options }}"
   args:
     chdir: "{{ ansible_user_dir }}/{{ zuul.project.src_dir }}/tests/"


### PR DESCRIPTION
We can use an ansible variable over a hardcoded value.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>