### PR TITLE
Promote base-minimal-test changes

### DIFF
--- a/playbooks/base-minimal/post-logs.yaml
+++ b/playbooks/base-minimal/post-logs.yaml
@@ -14,4 +14,3 @@
         name: upload-logs-swift
       vars:
         zuul_log_cloud_config: "{{ vexxhost_clouds_yaml }}"
-        zuul_log_partition: True

--- a/playbooks/base-minimal/pre.yaml
+++ b/playbooks/base-minimal/pre.yaml
@@ -4,7 +4,7 @@
       include_role:
         name: emit-job-header
       vars:
-        zuul_log_url: http://ansible-network.softwarefactory-project.io/logs/an
+        zuul_log_url: https://object-storage-ca-ymq-1.vexxhost.net/v1/a0b4156a37f9453eb4ec7db5422272df/logs
 
     - name: Run log-inventory role
       include_role:


### PR DESCRIPTION
This fixes the emit-job-header role to output the right URL for logs
now:

  https://object-storage-ca-ymq-1.vexxhost.net/swift/v1/a0b4156a37f9453eb4ec7db5422272df/logs/45/45/8d13b58b7114c0ae2150a1fc49113516f0b2487e/check/tox-linters/db282b8/

Signed-off-by: Paul Belanger <pabelanger@redhat.com>