### PR TITLE
Add ansible-network/sandbox to zuul

### DIFF
--- a/zuul.d/projects.yaml
+++ b/zuul.d/projects.yaml
@@ -34,3 +34,8 @@
         - cloud-vpn-aws-vyos-to-aws-vpn
         - cloud-vpn-aws-vyos-to-aws-vyos
         - cloud-vpn-aws-vyos-to-aws-vyos-bgp
+
+- project:
+    name: ansible-network/sandbox
+    templates:
+      - noop-jobs


### PR DESCRIPTION
We'll be using this project to test automation which zuul for the
ansible-network, this includes things like tagging releases.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>