### PR TITLE
Update post pipeline settings

### DIFF
--- a/zuul.d/pipelines.yaml
+++ b/zuul.d/pipelines.yaml
@@ -87,13 +87,17 @@
 
 - pipeline:
     name: post
-    post-review: true
-    description: This pipeline runs jobs that operate after each change is merged.
-    manager: independent
+    description: |
+      This pipeline runs jobs that operate after each change is
+      merged. Queue items are identified by the abbreviated hash (git
+      log --format=%h) of the merge commit.
+    manager: supercedent
     precedence: low
+    post-review: true
     trigger:
       github.com:
         - event: push
+          ref: ^refs/heads/.*$
     success:
       sqlreporter:
     failure:


### PR DESCRIPTION
Change to supercedent manager, since it is more efficent. And add ref
matcher for push events.  Since this was triggering when we tagged a
release.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>