### PR TITLE
Remove release-post pipeline

### DIFF
--- a/zuul.d/pipelines.yaml
+++ b/zuul.d/pipelines.yaml
@@ -148,21 +148,6 @@
       sqlreporter:
 
 - pipeline:
-    name: release-post
-    description: This pipeline runs release-process-critical jobs that operate after specific changes are merged.
-    manager: independent
-    precedence: high
-    post-review: true
-    trigger:
-      github.com:
-        - event: push
-          ref: ^refs/heads/.*$
-    success:
-      sqlreporter:
-    failure:
-      sqlreporter:
-
-- pipeline:
     name: third-party-check
     description: |
       Newly uploaded patchsets to projects that are external to OpenStack


### PR DESCRIPTION
We created this by mistake, there isn't a need for a dedicated
release-post pipeline. We can just use post for everything.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>