### PR TITLE
Remove gate label in check pipeline

### DIFF
--- a/zuul.d/pipelines.yaml
+++ b/zuul.d/pipelines.yaml
@@ -20,6 +20,8 @@
         status: 'pending'
         status-url: 'https://ansible-network.softwarefactory-project.io/zuul/status.html'
         comment: false
+        unlabel:
+          - gate
     success:
       github.com:
         status: 'success'


### PR DESCRIPTION
If a PR is in gate, and user pushes up a new patch, this means we
dequeue and add back to check.  We should also remove the gate label to
ensure somebody has to relabel the patch.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>