### PR TITLE
Add system-required template to all projects

### DIFF
--- a/zuul.d/projects.yaml
+++ b/zuul.d/projects.yaml
@@ -1,5 +1,12 @@
 ---
 - project:
+    # NOTE(pabelanger): All projects in ansible-network must run
+    # system-required project-template
+    name: ^github.com/ansible-network/.*
+    templates:
+      - system-required
+
+- project:
     name: ansible/ansible
     default-branch: devel
 


### PR DESCRIPTION
Start enforing system-required project-template for all projects.

Depends-On: https://github.com/ansible-network/ansible-zuul-jobs/pull/64
Signed-off-by: Paul Belanger <pabelanger@redhat.com>