### PR TITLE
Switch to build-tox-docs for zuul-config

### DIFF
--- a/zuul.d/projects.yaml
+++ b/zuul.d/projects.yaml
@@ -11,13 +11,13 @@
     default-branch: devel
 
 - project:
+    templates:
+      - build-tox-docs
     check:
       jobs:
-        - tox-docs
         - tox-linters
     gate:
       jobs:
-        - tox-docs
         - tox-linters
 
 - project:


### PR DESCRIPTION
This means we can use the 1vcpu nodeset.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>