### PR TITLE
Add release-ansible-role job

### DIFF
--- a/playbooks/publish/galaxy.yaml
+++ b/playbooks/publish/galaxy.yaml
@@ -1,0 +1,13 @@
+hosts: localhost
+tasks:
+  # TODO(pabelanger): Move to requirements.txt file?
+  - name: Pip install ansible-galaxy
+    command: pip install ansible --user
+
+  # TODO(pabelanger): Move into own role.
+  - name: Login into Ansible Galaxy with github token
+    command: "~/.local/bin/ansible-galaxy -s {{ galaxy_info.server }} login --github-token {{ galaxy_info.token }}"
+    no_log: True
+
+  - name: Import role into Ansible Galaxy
+    command: "~/.local/bin/ansible-galaxy -s {{ galaxy_info.server }} import {{ zuul.project['name'].split('/')[0] }} {{ zuul.project['short_name'] }}"

--- a/zuul.d/jobs.yaml
+++ b/zuul.d/jobs.yaml
@@ -68,6 +68,17 @@
     nodeset: fedora-latest
 
 - job:
+    name: release-ansible-role
+    description: |
+      Release ansible roles to galaxy.
+    final: true
+    run: playbooks/publish/galaxy.yaml
+    secrets:
+      - secret: galaxy_qa_secret
+        name: galaxy_info
+
+# TODO(pabelanger): Refactor everything below, most of this can be placed into untrusted jobs    
+- job:
     name: base-controller-appliance-minimal-test
     parent: null
     description: |

--- a/zuul.d/secrets.yaml
+++ b/zuul.d/secrets.yaml
@@ -27,6 +27,22 @@
       region_name: ca-ymq-1
 
 - secret:
+    name: galaxy_qa_secret
+    data:
+      server: https://galaxy-qa.ansible.com
+      token: !encrypted/pkcs1-oaep
+        - HeY/phpGqZ9qRPg2Dyj8dlevHsAo3jl/6K7LjBdr8yXA4L5bsUZX/GLqJ9ltcG8VJ0O8L
+          1uQKjXvJGfoEr+c8l57TDgrpnvPdkNfnBgfl2PNfcWqLxJSc7RSUTxQkVY+PZ52i7okm6
+          hg2412CRXFcUnRY3f3EXV52u6xkOBz8gWgvCwCr2VOpuoP+ul0Hn1X1hWOrecZysbzJN8
+          vlbp2SWeOYkeIc7XAva6wop2MY+rp0jymBwTq/NULOy78oHvRCUcYhv9kGhmFnStU8MPH
+          7TNpoU6PCGPBMafTwokocK2L+XtvVoluZG4JQke+L2PMD5kzrH2o1Vo2J+WgxGRiXlyFi
+          Kx3jHGMVMnqRRaKpD574qai7LYmpfVx5RkmxXX1NCK6lBzRB/6MFHYc5K2NRm7HaEVVUc
+          9wowlcCWCX6XJF2UtiwZMe4YwoiagPI7ncUpIEvRlwMKGdN/1WOQmaDv/FN+SGC87BbTI
+          q4VdSGAzk6vqhIit7HvVPg5VC4st5y52xQOIZFrCE1gMvXP7oX7EPIXwl/1ImpiUiVz3K
+          +ChSvDLe/q/jvlo0Vg6akvM+4KO3qbmu7NnO4rIJveFovhxmg6Oyv0sYQeQuavSu15muv
+          HkaqT9HTSpkxMWgN9FV9fm87zvoYHvlSS9pAMyFuDnVNVR5OBlXIQreqcR3YXI=
+
+- secret:
     name: site_ansiblelogs
     data:
       url: http://ansible-network.softwarefactory-project.io/logs/an


### PR DESCRIPTION
We'll be using this in the pre-release / release pipeline when we push a
tag for roles. This will allow zuul to properly trigger an import for
ansible-galaxy.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>