### PR TITLE
Remove nodeset for release-ansible-role

### DIFF
--- a/zuul.d/jobs.yaml
+++ b/zuul.d/jobs.yaml
@@ -73,6 +73,8 @@
       Release ansible roles to galaxy.
     final: true
     run: playbooks/publish/galaxy.yaml
+    nodeset:
+      nodes: []
     secrets:
       - secret: galaxy_secret
         name: galaxy_info


### PR DESCRIPTION
We don't actually need a node from nodepool to run ansible-galaxy, this
will save us some capacity.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>