### PR TITLE
Use zuul.branch for release-ansible-role

### DIFF
--- a/playbooks/publish/galaxy.yaml
+++ b/playbooks/publish/galaxy.yaml
@@ -15,4 +15,4 @@
       no_log: True
 
     - name: Import role into Ansible Galaxy
-      command: "{{ ansible_galaxy_executable }} -s {{ galaxy_info.server }} import {{ zuul.project['name'].split('/')[0] }} {{ zuul.project['short_name'] }}"
+      command: "{{ ansible_galaxy_executable }} -s {{ galaxy_info.server }} import --branch {{ zuul.branch }} {{ zuul.project['name'].split('/')[0] }} {{ zuul.project['short_name'] }}"


### PR DESCRIPTION
Have zuul setup the branch we want to use. Until we can build an upload
our own tarballs.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>