### PR TITLE
Use zuul.tag for release-ansible-role job

### DIFF
--- a/playbooks/publish/galaxy.yaml
+++ b/playbooks/publish/galaxy.yaml
@@ -15,4 +15,4 @@
       no_log: True
 
     - name: Import role into Ansible Galaxy
-      command: "{{ ansible_galaxy_executable }} -s {{ galaxy_info.server }} import --branch {{ zuul.branch }} {{ zuul.project['name'].split('/')[0] }} {{ zuul.project['short_name'] }}"
+      command: "{{ ansible_galaxy_executable }} -s {{ galaxy_info.server }} import --branch {{ zuul.tag }} {{ zuul.project['name'].split('/')[0] }} {{ zuul.project['short_name'] }}"


### PR DESCRIPTION
Try to use zuul.tag, since we are running this in the release pipeline.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>