### PR TITLE
Update ansible-network/sandbox to use release-jobs

### DIFF
--- a/zuul.d/projects.yaml
+++ b/zuul.d/projects.yaml
@@ -45,4 +45,4 @@
 - project:
     name: ansible-network/sandbox
     templates:
-      - noop-jobs
+      - ansible-role-release-jobs


### PR DESCRIPTION
We want to start testing the release pipeline with sandbox.

Depends-On: https://github.com/ansible-network/ansible-zuul-jobs/pull/67
Signed-off-by: Paul Belanger <pabelanger@redhat.com>