### PR TITLE
Switch to ansible-python-jobs project-templates

### DIFF
--- a/zuul.d/projects.yaml
+++ b/zuul.d/projects.yaml
@@ -12,20 +12,16 @@
 
 - project:
     templates:
+      - ansible-python-jobs
       - build-tox-docs
-    check:
-      jobs:
-        - tox-linters
-    gate:
-      jobs:
-        - tox-linters
 
 - project:
     name: github.com/ansible-network/cloud_vpn
     default-branch: devel
+    templates:
+      - ansible-python-jobs
     check:
       jobs:
-        - tox-linters
         - cloud-vpn-aws-csr-to-aws-vpn
         - cloud-vpn-aws-csr-to-aws-vpn-bgp
         - cloud-vpn-aws-csr-to-aws-vyos
@@ -34,7 +30,6 @@
         - cloud-vpn-aws-vyos-to-aws-vyos-bgp
     gate:
       jobs:
-        - tox-linters
         - cloud-vpn-aws-csr-to-aws-vpn
         - cloud-vpn-aws-csr-to-aws-vpn-bgp
         - cloud-vpn-aws-csr-to-aws-vyos


### PR DESCRIPTION
This updates both zuul-config and cloud_vpn to use new
ansible-python-jobs template. We'll be onboarding more projects shortly.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>