### PR TITLE
Add ansible-network/network-engine to projects.yaml

### DIFF
--- a/zuul.d/projects.yaml
+++ b/zuul.d/projects.yaml
@@ -37,6 +37,13 @@
         - cloud-vpn-aws-vyos-to-aws-vyos
         - cloud-vpn-aws-vyos-to-aws-vyos-bgp
 
+
+- project:
+    name: github.com/ansible-network/network-engine
+    default-branch: devel
+    templates:
+      - ansible-python-jobs
+
 - project:
     name: github.com/ansible-network/sandbox
     templates:


### PR DESCRIPTION
Centralize the running of our PTI jobs, to help ensure all roles do
this.  We may want to consider moving this inrepo for PTI jobs, but for
now lets start here.

Depends-On: https://github.com/ansible-network/network-engine/pull/162
Signed-off-by: Paul Belanger <pabelanger@redhat.com>