### PR TITLE
Add python-ansible-jobs to ansible-network/cisco_ios

### DIFF
--- a/zuul.d/projects.yaml
+++ b/zuul.d/projects.yaml
@@ -7,6 +7,12 @@
       - system-required
 
 - project:
+    name: github.com/ansible-network/cisco_ios
+    default-branch: devel
+    templates:
+      - ansible-python-jobs
+
+- project:
     name: github.com/ansible-network/cloud_vpn
     default-branch: devel
     templates:


### PR DESCRIPTION
Bring online another project with our default linters job.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>