### PR TITLE
Add python-ansible-jobs to ansible-network/cisco_iosxr

### DIFF
--- a/zuul.d/projects.yaml
+++ b/zuul.d/projects.yaml
@@ -19,6 +19,12 @@
       - ansible-python-jobs
 
 - project:
+    name: github.com/ansible-network/cisco_iosxr
+    default-branch: devel
+    templates:
+      - ansible-python-jobs
+
+- project:
     name: github.com/ansible-network/cisco_nxos
     default-branch: devel
     templates:


### PR DESCRIPTION
Make sure ansible-network/cisco_iosxr is running PTI jobs.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>