### PR TITLE
Update base-minimal-test to use fedora-latest-1vcpu

### DIFF
--- a/zuul.d/jobs.yaml
+++ b/zuul.d/jobs.yaml
@@ -65,7 +65,7 @@
       ara_compress_html: false
     secrets:
       - vexxhost_clouds_yaml
-    nodeset: fedora-latest
+    nodeset: fedora-latest-1vcpu
 
 - job:
     name: release-ansible-role


### PR DESCRIPTION
We are planing on removing the fedora-latest nodeset, default all jobs
to 1vcpu. If jobs need more, we are able to override the default
nodeset.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>