### PR TITLE
Switch to ansible-fedora-28-4vcpu for cloud_vpn jobs

### DIFF
--- a/zuul.d/jobs.yaml
+++ b/zuul.d/jobs.yaml
@@ -98,7 +98,7 @@
     nodeset:
       nodes:
         - name: controller
-          label: ansible-fedora-28
+          label: ansible-fedora-28-4vcpu
         - name: appliance
           label: ansible-network-vqfx
 
@@ -228,6 +228,6 @@
     nodeset:
       nodes:
         - name: controller
-          label: ansible-fedora-28
+          label: ansible-fedora-28-4vcpu
         - name: appliance
           label: ansible-network-vqfx


### PR DESCRIPTION
We are going to remove ansible-fedora-28 from nodepool, and use new
flavor based labels.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>