### PR TITLE
Pass ansible_galaxy_executable into ansible-galaxy-import

### DIFF
--- a/playbooks/publish/galaxy.yaml
+++ b/playbooks/publish/galaxy.yaml
@@ -12,3 +12,5 @@
     - name: Run ansible-galaxy-import role
       include_role:
         name: ansible-galaxy-import
+      vars:
+        ansible_galaxy_executable: "{{ ansible_galaxy_executable }}"


### PR DESCRIPTION
Make sure we are properly setting up the patch to
ansible_galaxy_executable.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>