### PR TITLE
Update release-ansible-role job for new secret name

### DIFF
--- a/zuul.d/jobs.yaml
+++ b/zuul.d/jobs.yaml
@@ -77,7 +77,7 @@
       nodes: []
     secrets:
       - secret: galaxy_secret
-        name: galaxy_info
+        name: ansible_galaxy_info
 
 # TODO(pabelanger): Refactor everything below, most of this can be placed into untrusted jobs    
 - job:


### PR DESCRIPTION
We also need to update the secret we pass to ansible-galaxy-import, this
has changed for the upstream role.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>