### PR TITLE
Email failures for release pipelines

### DIFF
--- a/zuul.d/pipelines.yaml
+++ b/zuul.d/pipelines.yaml
@@ -105,6 +105,11 @@
     success:
       sqlreporter:
     failure:
+      smtp:
+        # TODO(pabelanger): Setup properly email addresses.
+        from: zuul@ansible.org
+        to: pabelanger@gmail.com
+        subject: 'Release of {change.project} failed'
       sqlreporter:
 
 - pipeline:
@@ -120,6 +125,11 @@
     success:
       sqlreporter:
     failure:
+      smtp:
+        # TODO(pabelanger): Setup properly email addresses.
+        from: zuul@ansible.org
+        to: pabelanger@gmail.com
+        subject: 'Pre-release of {change.project} failed'
       sqlreporter:
 
 - pipeline:


### PR DESCRIPTION
It is helpful to get an email if this pre-release/release jobs fail. For
now, test using my personal account to ensure they work, before posting
them to a public ML.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>