### PR TITLE
Add dco-license job

### DIFF
--- a/playbooks/dco-license/run.yaml
+++ b/playbooks/dco-license/run.yaml
@@ -1,0 +1,5 @@
+- hosts: localhost
+  tasks:
+    - name: Run validate-dco-license role
+      include_role:
+        name: validate-dco-license

--- a/zuul.d/jobs.yaml
+++ b/zuul.d/jobs.yaml
@@ -68,6 +68,16 @@
     nodeset: fedora-latest-1vcpu
 
 - job:
+    name: dco-license
+    description: |
+      A job to validate all commits for a PR have been signed using --signoff.
+    run: playbooks/dco-license/run.yaml
+    roles:
+      - zuul: github.com/ansible-network/ansible-zuul-jobs
+    nodeset:
+      nodes: []
+
+- job:
     name: release-ansible-role
     description: |
       Release ansible roles to galaxy.


### PR DESCRIPTION
We'll be using this job to validate all commit into
github.com/ansible-network namespace are follow the DCO license.

Depends-On: https://github.com/ansible-network/ansible-zuul-jobs/pull/73
Signed-off-by: Paul Belanger <pabelanger@redhat.com>