### PR TITLE
Setup correct zuul_work_dir path for dco-license job

### DIFF
--- a/playbooks/dco-license/run.yaml
+++ b/playbooks/dco-license/run.yaml
@@ -3,3 +3,5 @@
     - name: Run validate-dco-license role
       include_role:
         name: validate-dco-license
+      vars:
+        zuul_work_dir: "{{ zuul.executor.src_root }}/{{ zuul.project.src_dir }}"


### PR DESCRIPTION
Because we run this job on localhost (zuul-executor) we need to change
to the correct directory.

Depends-On: https://github.com/ansible-network/ansible-zuul-jobs/pull/74
Signed-off-by: Paul Belanger <pabelanger@redhat.com>