### PR TITLE
Add tox-py27 / tox-py36 jobs to ansible-network/network-engine

### DIFF
--- a/zuul.d/projects.yaml
+++ b/zuul.d/projects.yaml
@@ -63,6 +63,14 @@
     default-branch: devel
     templates:
       - ansible-python-jobs
+    check:
+      jobs:
+        - tox-py27
+        - tox-py36
+    gate:
+      jobs:
+        - tox-py27
+        - tox-py36
 
 - project:
     name: github.com/ansible-network/sandbox


### PR DESCRIPTION
Move these into azj so we can centralize our job configuration.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>