### PR TITLE
Add ansible-python-jobs to yang

### DIFF
--- a/zuul.d/projects.yaml
+++ b/zuul.d/projects.yaml
@@ -83,6 +83,11 @@
       - ansible-python-jobs
 
 - project:
+    name: github.com/ansible-network/yang
+    templates:
+      - ansible-python-jobs
+
+- project:
     name: github.com/ansible-network/zuul-config
     templates:
       - ansible-python-jobs


### PR DESCRIPTION
We've fixed yang to support tox, lets also run linter jobs.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>