### PR TITLE
Switch network-engine to new tox jobs

### DIFF
--- a/zuul.d/projects.yaml
+++ b/zuul.d/projects.yaml
@@ -65,12 +65,12 @@
       - ansible-python-jobs
     check:
       jobs:
-        - tox-py27
-        - tox-py36
+        - ansible-network-tox-py27
+        - ansible-network-tox-py36
     gate:
       jobs:
-        - tox-py27
-        - tox-py36
+        - ansible-network-tox-py27
+        - ansible-network-tox-py36
 
 - project:
     name: github.com/ansible-network/sandbox


### PR DESCRIPTION
These jobs now provide specific things we want for ansible-network, like
nested ARA reports and SSH keys for localhost in the future.

Depends-On: https://github.com/ansible-network/ansible-zuul-jobs/pull/80
Signed-off-by: Paul Belanger <pabelanger@redhat.com>