### PR TITLE
Add tag pipeline

### DIFF
--- a/zuul.d/pipelines.yaml
+++ b/zuul.d/pipelines.yaml
@@ -93,6 +93,26 @@
       sqlreporter:
 
 - pipeline:
+    name: tag
+    description: This pipeline runs jobs in response to any tag event.
+    manager: independent
+    precedence: high
+    post-review: True
+    trigger:
+      github.com:
+        - event: push
+          ref: ^refs/tags/.*$
+    success:
+      sqlreporter:
+    failure:
+      smtp:
+        # TODO(pabelanger): Setup properly email addresses.
+        from: zuul@ansible.org
+        to: pabelanger@gmail.com
+        subject: 'Tag of {change.project} failed'
+      sqlreporter:
+
+- pipeline:
     name: pre-release
     description: When a commit is tagged with a pre-release tag, this pipeline runs jobs that publish archives and documentation.
     manager: independent


### PR DESCRIPTION
Until we figure out if we are using semver for release or not, add a
generic tag pipeline which will respond to any tag.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>