### PR TITLE
Switch sandbox to use ansible-role-tag-jobs

### DIFF
--- a/zuul.d/projects.yaml
+++ b/zuul.d/projects.yaml
@@ -75,7 +75,7 @@
 - project:
     name: github.com/ansible-network/sandbox
     templates:
-      - ansible-role-release-jobs
+      - ansible-role-tag-jobs
 
 - project:
     name: github.com/ansible-network/vyos


### PR DESCRIPTION
This is to make sure our new pipeline works as expected.

Depends-On: https://github.com/ansible-network/ansible-zuul-jobs/pull/81
Signed-off-by: Paul Belanger <pabelanger@redhat.com>