### PR TITLE
make pipeline precedence progressively higher

### DIFF
--- a/zuul.d/pipelines.yaml
+++ b/zuul.d/pipelines.yaml
@@ -5,6 +5,7 @@
       Newly uploaded patchsets enter this pipeline to receive an
       initial +/-1 Verified vote.
     manager: independent
+    precedence: low
     trigger:
       github.com:
         - event: pull_request
@@ -40,7 +41,7 @@
       Build failed (gate pipeline).  For information on how to proceed, see
       http://docs.openstack.org/infra/manual/developers.html#automated-testing
     manager: dependent
-    precedence: high
+    precedence: normal
     require:
       github.com:
         label:
@@ -81,7 +82,7 @@
       merged. Queue items are identified by the abbreviated hash (git
       log --format=%h) of the merge commit.
     manager: supercedent
-    precedence: low
+    precedence: high
     post-review: true
     trigger:
       github.com:
@@ -171,6 +172,7 @@
     description: |
       If a PR is pushed to and has the gate label, we want to remove that.
     manager: independent
+    precedence: high
     trigger:
       github.com:
         - event: pull_request
@@ -194,6 +196,6 @@
       on the same project are still mergeable.
     failure-message: Build failed (merge-check pipeline).
     manager: independent
-    ignore-dependencies: true
     precedence: low
+    ignore-dependencies: true
     trigger: {}


### PR DESCRIPTION
This patch changes the precedence settings for pipelines so that they
become progressively higher. Under high load, this is expected to have
the effect of prioritizing jobs needed to "finish" one patch
completely over jobs related to patches that are not as far along in
the approval process, which should prevent the post and gate pipeline
queues from backing up at the expense of making the check pipeline
queues deeper.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>