### PR TITLE
Default to python3 for linters

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -8,9 +8,11 @@ install_command = pip install {opts} {packages}
 deps = -r{toxinidir}/test-requirements.txt
 
 [testenv:docs]
+basepython = python3
 commands = python setup.py build_sphinx
 
 [testenv:linters]
+basepython = python3
 commands =
   flake8
   {toxinidir}/tools/zuul-projects-checks.py


### PR DESCRIPTION
We run on fedora, so might as well testing against python3.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>