### PR TITLE
Add ansible-role-tag-jobs template to cisco_iosxr

### DIFF
--- a/zuul.d/projects.yaml
+++ b/zuul.d/projects.yaml
@@ -23,6 +23,7 @@
     default-branch: devel
     templates:
       - ansible-python-jobs
+      - ansible-role-tag-jobs
 
 - project:
     name: github.com/ansible-network/cisco_nxos


### PR DESCRIPTION
Lets use the tag pipeline for cisco_iosxr jobs.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>