### PR TITLE
Add ansible-network/releases to zuul

### DIFF
--- a/zuul.d/projects.yaml
+++ b/zuul.d/projects.yaml
@@ -79,6 +79,11 @@
         - ansible-network-tox-py36
 
 - project:
+    name: github.com/ansible-network/releases
+    templates:
+      - noop-jobs
+
+- project:
     name: github.com/ansible-network/sandbox
     templates:
       - ansible-role-tag-jobs


### PR DESCRIPTION
Default to noop-jobs until we can properly bootstrap the repo.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>