### PR TITLE
Add ansible-network/packet-ci-cloud to zuul

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -23,6 +23,6 @@ commands = {posargs}
 [flake8]
 # These are ignored intentionally;
 # please don't submit patches that solely correct them or enable them.
-ignore = E125,E129,H
+ignore = E125,E129,H,W504
 show-source = True
 exclude = .venv,.tox,dist,doc,build,*.egg

--- a/zuul.d/projects.yaml
+++ b/zuul.d/projects.yaml
@@ -79,6 +79,11 @@
         - ansible-network-tox-py36
 
 - project:
+    name: github.com/ansible-network/packet-ci-cloud
+    templates:
+      - noop-jobs
+
+- project:
     name: github.com/ansible-network/releases
     templates:
       - noop-jobs


### PR DESCRIPTION
Add noop-jobs to ansible-network/packet-ci-cloud so we can start gating.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>