### PR TITLE
Switch release-ansible-annoucement to use zuul-executor

### DIFF
--- a/playbooks/release/run.yaml
+++ b/playbooks/release/run.yaml
@@ -1,19 +1,19 @@
-- hosts: all
+- hosts: localhost
   tasks:
     - name: Setup tweetrc credentials
       copy:
         content: "{{ twitter_ansible_network.credentials }}"
         dest: ~/.tweetrc
 
+    - name: Ensure tox is installed
+      shell: pip install --user tox
+
     - name: Bootstrap tox environment
       args:
         chdir: "{{ zuul.projects['github.com/ansible-network/releases'].src_dir }}"
-      command: tox -evenv --notest
+      command: "{{ ansible_user_dir }}/.local/bin/tox -evenv --notest"
 
     - name: Send twitter announcement
       args:
         chdir: "{{ zuul.projects['github.com/ansible-network/releases'].src_dir }}"
-        executable: /bin/bash
-      shell: |
-        source .tox/venv/bin/activate
-        ./tools/twitter-annoucement.py {{ zuul.project.short_name }} {{ zuul.tag }} https://galaxy.ansible.com/{{ zuul.project.short_name }}
+      shell: "{{ ansible_user_dir }}/.tox/venv/bin/python tools/twitter-annoucement.py {{ zuul.project.short_name }} {{ zuul.tag }} https://galaxy.ansible.com/{{ zuul.project.short_name }}"

--- a/zuul.d/jobs.yaml
+++ b/zuul.d/jobs.yaml
@@ -96,6 +96,8 @@
     run: playbooks/release/run.yaml
     required-projects:
       - ansible-network/releases
+    nodeset:
+      nodes: []
     secrets:
       - twitter_ansible_network
 


### PR DESCRIPTION
We actually can save some nodepool resources here and just default to
using the zuul-executor for sending out twitter messages.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>