### PR TITLE
Remove usage of ansible_user_dir for executor jobs

### DIFF
--- a/playbooks/release/run.yaml
+++ b/playbooks/release/run.yaml
@@ -11,9 +11,9 @@
     - name: Bootstrap tox environment
       args:
         chdir: "{{ zuul.projects['github.com/ansible-network/releases'].src_dir }}"
-      command: "{{ ansible_user_dir }}/.local/bin/tox -evenv --notest"
+      shell: ~/.local/bin/tox -evenv --notest
 
     - name: Send twitter announcement
       args:
         chdir: "{{ zuul.projects['github.com/ansible-network/releases'].src_dir }}"
-      shell: "{{ ansible_user_dir }}/.tox/venv/bin/python tools/twitter-annoucement.py {{ zuul.project.short_name }} {{ zuul.tag }} https://galaxy.ansible.com/{{ zuul.project.short_name }}"
+      shell: ".tox/venv/bin/python tools/twitter-annoucement.py {{ zuul.project.short_name }} {{ zuul.tag }} https://galaxy.ansible.com/{{ zuul.project.short_name }}"


### PR DESCRIPTION
We don't gather facts on these servers, so don't us ansible variables.
Also fixed a bug with tweet-announcement path.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>