### PR TITLE
Add ansible-network-tox-py37 job to network-engine

### DIFF
--- a/zuul.d/projects.yaml
+++ b/zuul.d/projects.yaml
@@ -73,10 +73,12 @@
       jobs:
         - ansible-network-tox-py27
         - ansible-network-tox-py36
+        - ansible-network-tox-py37
     gate:
       jobs:
         - ansible-network-tox-py27
         - ansible-network-tox-py36
+        - ansible-network-tox-py37
 
 - project:
     name: github.com/ansible-network/packet-ci-cloud


### PR DESCRIPTION
Start testing with python37, since we have accesss to it.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>