### PR TITLE
Move yang jobs in-tree

### DIFF
--- a/zuul.d/projects.yaml
+++ b/zuul.d/projects.yaml
@@ -106,6 +106,23 @@
     templates:
       - ansible-python-jobs
       - ansible-role-tag-jobs
+    check:
+      jobs:
+        - ansible-network-tox-py27:
+            required-projects:
+              - name: github.com/ansible-network/network-engine
+        - ansible-network-tox-py36:
+            required-projects:
+              - name: github.com/ansible-network/network-engine
+    gate:
+      jobs:
+        - ansible-network-tox-py27:
+            required-projects:
+              - name: github.com/ansible-network/network-engine
+        - ansible-network-tox-py36:
+            required-projects:
+              - name: github.com/ansible-network/network-engine
+
 
 - project:
     name: github.com/ansible-network/zuul-config


### PR DESCRIPTION
Centralize the jobs used for yang, to make it easier to control how they
are configured.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>