### PR TITLE
Add python37 jobs to ansible-network/yang

### DIFF
--- a/zuul.d/projects.yaml
+++ b/zuul.d/projects.yaml
@@ -114,6 +114,9 @@
         - ansible-network-tox-py36:
             required-projects:
               - name: github.com/ansible-network/network-engine
+        - ansible-network-tox-py37:
+            required-projects:
+              - name: github.com/ansible-network/network-engine
     gate:
       jobs:
         - ansible-network-tox-py27:
@@ -122,7 +125,9 @@
         - ansible-network-tox-py36:
             required-projects:
               - name: github.com/ansible-network/network-engine
-
+        - ansible-network-tox-py37:
+            required-projects:
+              - name: github.com/ansible-network/network-engine
 
 - project:
     name: github.com/ansible-network/zuul-config


### PR DESCRIPTION
We now have access to python3.7, start testing yang with it.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>