### PR TITLE
In-tree ansible-network/juniper_junos tox jobs

### DIFF
--- a/zuul.d/projects.yaml
+++ b/zuul.d/projects.yaml
@@ -62,6 +62,16 @@
     templates:
       - ansible-python-jobs
       - ansible-role-tag-jobs
+    check:
+      jobs:
+        - ansible-network-tox-py27
+        - ansible-network-tox-py36
+        - ansible-network-tox-py37
+    gate:
+      jobs:
+        - ansible-network-tox-py27
+        - ansible-network-tox-py36
+        - ansible-network-tox-py37
 
 - project:
     name: github.com/ansible-network/network-engine


### PR DESCRIPTION
This moves the jobs to a single location, making it easier to manage.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>