### PR TITLE
Remove dco-license job stanza

### DIFF
--- a/zuul.d/jobs.yaml
+++ b/zuul.d/jobs.yaml
@@ -68,16 +68,6 @@
     nodeset: fedora-latest-1vcpu
 
 - job:
-    name: dco-license
-    description: |
-      A job to validate all commits for a PR have been signed using --signoff.
-    run: playbooks/dco-license/run.yaml
-    roles:
-      - zuul: github.com/ansible-network/ansible-zuul-jobs
-    nodeset:
-      nodes: []
-
-- job:
     name: release-ansible-role
     description: |
       Release ansible roles to galaxy.


### PR DESCRIPTION
This has been merged upstream in zuul-jobs.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>