### PR TITLE
Run tox jobs for cisco_ios

### DIFF
--- a/zuul.d/projects.yaml
+++ b/zuul.d/projects.yaml
@@ -19,6 +19,16 @@
     templates:
       - ansible-python-jobs
       - ansible-role-tag-jobs
+    check:
+      jobs:
+        - ansible-network-tox-py27
+        - ansible-network-tox-py36
+        - ansible-network-tox-py37
+    gate:
+      jobs:
+        - ansible-network-tox-py27
+        - ansible-network-tox-py36
+        - ansible-network-tox-py37
 
 - project:
     name: github.com/ansible-network/cisco_iosxr


### PR DESCRIPTION
We want to start gating via tox jobs, enable it.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>