### PR TITLE
Remove ansible-network/packet-ci-cloud from zuul

### DIFF
--- a/zuul.d/projects.yaml
+++ b/zuul.d/projects.yaml
@@ -106,11 +106,6 @@
         - ansible-network-tox-py37
 
 - project:
-    name: github.com/ansible-network/packet-ci-cloud
-    templates:
-      - noop-jobs
-
-- project:
     name: github.com/ansible-network/releases
     templates:
       - noop-jobs


### PR DESCRIPTION
We no longer gate this project.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>