### PR TITLE
Remove ansible-network/cisco_iosxr project

### DIFF
--- a/zuul.d/projects.yaml
+++ b/zuul.d/projects.yaml
@@ -36,13 +36,6 @@
               - name: github.com/ansible-network/network-engine
 
 - project:
-    name: github.com/ansible-network/cisco_iosxr
-    default-branch: devel
-    templates:
-      - ansible-python-jobs
-      - ansible-role-tag-jobs
-
-- project:
     name: github.com/ansible-network/cloud_vpn
     default-branch: devel
     templates:


### PR DESCRIPTION
We no longer gate this project with zuul.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>