### PR TITLE
Remove ansible-network/vyos jobs

### DIFF
--- a/zuul.d/jobs.yaml
+++ b/zuul.d/jobs.yaml
@@ -101,7 +101,7 @@
       - name: ansible-network/network-engine
       # - name: ansible-network/aws
       - name: ansible-network/cisco_ios
-      - name: ansible-network/vyos
+      # - name: ansible-network/vyos
     timeout: 3600
     secrets:
       - aws
@@ -120,7 +120,7 @@
       - name: ansible-network/network-engine
       # - name: ansible-network/aws
       - name: ansible-network/cisco_ios
-      - name: ansible-network/vyos
+      # - name: ansible-network/vyos
     timeout: 3600
     secrets:
       - aws
@@ -139,7 +139,7 @@
       - name: ansible-network/network-engine
       # - name: ansible-network/aws
       - name: ansible-network/cisco_ios
-      - name: ansible-network/vyos
+      # - name: ansible-network/vyos
     timeout: 3600
     secrets:
       - aws
@@ -158,7 +158,7 @@
       - name: ansible-network/network-engine
       # - name: ansible-network/aws
       - name: ansible-network/cisco_ios
-      - name: ansible-network/vyos
+      # - name: ansible-network/vyos
     timeout: 3600
     secrets:
       - aws
@@ -177,7 +177,7 @@
       - name: ansible-network/network-engine
       # - name: ansible-network/aws
       - name: ansible-network/cisco_ios
-      - name: ansible-network/vyos
+      # - name: ansible-network/vyos
     timeout: 3600
     secrets:
       - aws
@@ -196,7 +196,7 @@
       - name: ansible-network/network-engine
       # - name: ansible-network/aws
       - name: ansible-network/cisco_ios
-      - name: ansible-network/vyos
+      # - name: ansible-network/vyos
     timeout: 3600
     secrets:
       - aws

--- a/zuul.d/projects.yaml
+++ b/zuul.d/projects.yaml
@@ -75,22 +75,6 @@
         - ansible-network-tox-py37
 
 - project:
-    name: github.com/ansible-network/vyos
-    templates:
-      - ansible-python-jobs
-      - ansible-role-tag-jobs
-    check:
-      jobs:
-        - ansible-network-tox-py27
-        - ansible-network-tox-py36
-        - ansible-network-tox-py37
-    gate:
-      jobs:
-        - ansible-network-tox-py27
-        - ansible-network-tox-py36
-        - ansible-network-tox-py37
-
-- project:
     name: github.com/ansible-network/yang
     templates:
       - ansible-python-jobs


### PR DESCRIPTION
Start the migration of ansible-network/vyos to zuul.ansible.com.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>