### PR TITLE
Remove ansible-network/yang jobs

### DIFF
--- a/zuul.d/projects.yaml
+++ b/zuul.d/projects.yaml
@@ -75,34 +75,6 @@
         - ansible-network-tox-py37
 
 - project:
-    name: github.com/ansible-network/yang
-    templates:
-      - ansible-python-jobs
-      - ansible-role-tag-jobs
-    check:
-      jobs:
-        - ansible-network-tox-py27:
-            required-projects:
-              - name: github.com/ansible-network/network-engine
-        - ansible-network-tox-py36:
-            required-projects:
-              - name: github.com/ansible-network/network-engine
-        - ansible-network-tox-py37:
-            required-projects:
-              - name: github.com/ansible-network/network-engine
-    gate:
-      jobs:
-        - ansible-network-tox-py27:
-            required-projects:
-              - name: github.com/ansible-network/network-engine
-        - ansible-network-tox-py36:
-            required-projects:
-              - name: github.com/ansible-network/network-engine
-        - ansible-network-tox-py37:
-            required-projects:
-              - name: github.com/ansible-network/network-engine
-
-- project:
     name: github.com/ansible-network/zuul-config
     templates:
       - ansible-python-jobs


### PR DESCRIPTION
We are in the process of migration this project to zuul.ansible.com.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>