### PR TITLE
Remove ansible-network/cisco_ios jobs

### DIFF
--- a/zuul.d/jobs.yaml
+++ b/zuul.d/jobs.yaml
@@ -100,7 +100,7 @@
     required-projects:
       - name: ansible-network/network-engine
       # - name: ansible-network/aws
-      - name: ansible-network/cisco_ios
+      # - name: ansible-network/cisco_ios
       # - name: ansible-network/vyos
     timeout: 3600
     secrets:
@@ -119,7 +119,7 @@
     required-projects:
       - name: ansible-network/network-engine
       # - name: ansible-network/aws
-      - name: ansible-network/cisco_ios
+      # - name: ansible-network/cisco_ios
       # - name: ansible-network/vyos
     timeout: 3600
     secrets:
@@ -138,7 +138,7 @@
     required-projects:
       - name: ansible-network/network-engine
       # - name: ansible-network/aws
-      - name: ansible-network/cisco_ios
+      # - name: ansible-network/cisco_ios
       # - name: ansible-network/vyos
     timeout: 3600
     secrets:
@@ -157,7 +157,7 @@
     required-projects:
       - name: ansible-network/network-engine
       # - name: ansible-network/aws
-      - name: ansible-network/cisco_ios
+      # - name: ansible-network/cisco_ios
       # - name: ansible-network/vyos
     timeout: 3600
     secrets:
@@ -176,7 +176,7 @@
     required-projects:
       - name: ansible-network/network-engine
       # - name: ansible-network/aws
-      - name: ansible-network/cisco_ios
+      # - name: ansible-network/cisco_ios
       # - name: ansible-network/vyos
     timeout: 3600
     secrets:
@@ -195,7 +195,7 @@
     required-projects:
       - name: ansible-network/network-engine
       # - name: ansible-network/aws
-      - name: ansible-network/cisco_ios
+      # - name: ansible-network/cisco_ios
       # - name: ansible-network/vyos
     timeout: 3600
     secrets:

--- a/zuul.d/projects.yaml
+++ b/zuul.d/projects.yaml
@@ -7,35 +7,6 @@
       - system-required
 
 - project:
-    name: github.com/ansible-network/cisco_ios
-    default-branch: devel
-    templates:
-      - ansible-python-jobs
-      - ansible-role-tag-jobs
-    check:
-      jobs:
-        - ansible-network-tox-py27:
-            required-projects:
-              - name: github.com/ansible-network/network-engine
-        - ansible-network-tox-py36:
-            required-projects:
-              - name: github.com/ansible-network/network-engine
-        - ansible-network-tox-py37:
-            required-projects:
-              - name: github.com/ansible-network/network-engine
-    gate:
-      jobs:
-        - ansible-network-tox-py27:
-            required-projects:
-              - name: github.com/ansible-network/network-engine
-        - ansible-network-tox-py36:
-            required-projects:
-              - name: github.com/ansible-network/network-engine
-        - ansible-network-tox-py37:
-            required-projects:
-              - name: github.com/ansible-network/network-engine
-
-- project:
     name: github.com/ansible-network/cloud_vpn
     default-branch: devel
     templates:


### PR DESCRIPTION
Start the process to migrate ansible-network/cisco_ios to
zuul.ansible.com.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>