### PR TITLE
Switch to noop-jobs for ansible-network/zuul-config

### DIFF
--- a/zuul.d/projects.yaml
+++ b/zuul.d/projects.yaml
@@ -31,5 +31,4 @@
 - project:
     name: github.com/ansible-network/zuul-config
     templates:
-      - ansible-python-jobs
-      - build-tox-docs
+      - noop-jobs


### PR DESCRIPTION
We don't need to use nodepool any more.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>